### PR TITLE
enforce mrn data type to avoid join issue

### DIFF
--- a/08 - Delta Live Tables/DE 8.2 DLT Lab/DE 8.2.2L - Migrating a SQL Pipeline to DLT Lab.sql
+++ b/08 - Delta Live Tables/DE 8.2 DLT Lab/DE 8.2.2L - Migrating a SQL Pipeline to DLT Lab.sql
@@ -36,7 +36,7 @@
 -- TODO
 CREATE <FILL-IN>
 AS SELECT <FILL-IN>
-  FROM cloud_files("${source}", "json", map("cloudFiles.schemaHints", "time DOUBLE"))
+  FROM cloud_files("${source}", "json", map("cloudFiles.schemaHints", "time DOUBLE mrn INTEGER"))
 
 -- COMMAND ----------
 


### PR DESCRIPTION
When reading the JSON files (for bronze table), mrn data is read as a string. This will cause a join issue in the later part as mrn is read as integer in pii table. 

Note: I realise that all other PRs are asked (@SireInsectus ) to raise the issue in "Curriculum-Dev" workspace. But I'm not sure what that means so raising a PR here regardless.