### PR TITLE
Fixed typo

### DIFF
--- a/06 - Incremental Data Processing/DE 6.1 - Incremental Data Ingestion with Auto Loader.py
+++ b/06 - Incremental Data Processing/DE 6.1 - Incremental Data Ingestion with Auto Loader.py
@@ -134,7 +134,7 @@ def block_until_stream_is_ready(query, min_batches=2):
     while len(query.recentProgress) < min_batches:
         time.sleep(5) # Give it a couple of seconds
 
-    print(f"The stream has processed {len(query.recentProgress)} batchs")
+    print(f"The stream has processed {len(query.recentProgress)} batches")
 
 block_until_stream_is_ready(query)
 


### PR DESCRIPTION
In the word "batchs" (should be batches).