### PR TITLE
Correcting the Data Type for timestamp field

### DIFF
--- a/04 - ETL with Spark SQL/DE 4.3 - Creating Delta Tables.sql
+++ b/04 - ETL with Spark SQL/DE 4.3 - Creating Delta Tables.sql
@@ -157,7 +157,7 @@ SELECT * FROM purchases_vw
 
 CREATE OR REPLACE TABLE purchase_dates (
   id STRING, 
-  transaction_timestamp LONG, 
+  transaction_timestamp STRING, 
   price STRING,
   date DATE GENERATED ALWAYS AS (
     cast(cast(transaction_timestamp/1e6 AS TIMESTAMP) AS DATE))


### PR DESCRIPTION
When `transaction_timestamp` is set LONG, the cell after this CREATE TABLE cell is raising ERROR. 

CREATE OR REPLACE TABLE purchase_dates (
  id STRING, 
  transaction_timestamp LONG, 
  price STRING,
  date DATE GENERATED ALWAYS AS (
    cast(cast(transaction_timestamp/1e6 AS TIMESTAMP) AS DATE))
    COMMENT "generated based on `transactions_timestamp` column")