### PR TITLE
Add source to advanced pipeline configuration

### DIFF
--- a/08 - Delta Live Tables/DE 8.2 - DLT Lab/DE 8.2.1L - Lab Instructions.py
+++ b/08 - Delta Live Tables/DE 8.2 - DLT Lab/DE 8.2.1L - Lab Instructions.py
@@ -115,6 +115,7 @@ DA.print_pipeline_config()
 # MAGIC | ------------- | ------------------- | ------------------------------------------ |
 # MAGIC | #1            | **`spark.master`**  | **`local[*]`**                             |
 # MAGIC | #2            | **`datasets_path`** | Enter the **Datasets Path** provided above |
+# MAGIC | #3            | **`source`**        | Enter the **Source** provided above        |
 # MAGIC 
 # MAGIC Finally, click **Create**.
 


### PR DESCRIPTION
Run into path issue due to source not specified in pipeline configuration `org.apache.spark.sql.AnalysisException: Unable to process statement for table 'recordings_bronze'.` `java.lang.IllegalArgumentException: Can not create a Path from an empty string`